### PR TITLE
Update "Getting Started" markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [Adam Bradley](http://twitter.com/adamdbradley)'s [Building apps with Ionic 
 
 ### Try Ionic 2
 
-To try Ionic 2 today, visit the [http://ionicframework.com/docs/v2/getting-started/](Getting Started) page. We would love any feedback you have or to know when you encounter issues, by filing an issue report on this repo.
+To try Ionic 2 today, visit the [Getting Started](http://ionicframework.com/docs/v2/getting-started/installation/) page. We would love any feedback you have or to know when you encounter issues, by filing an issue report on this repo.
 
 ### Ionic 2 Examples
 


### PR DESCRIPTION
There was a small error, almost just a typo on the README.

Now it correctly points to the docs.
